### PR TITLE
fixed while condition in encode_matches_count so it doesn't get stuck…

### DIFF
--- a/main.c
+++ b/main.c
@@ -651,7 +651,7 @@ void update_tmp_crc_data(vars_t *v, uint8 b)
 
 void encode_matches_count(vars_t *v, int count)
 {
-    while (count)
+    while (count > 0)
     {
         if (count >= 12)
         {


### PR DESCRIPTION
… when count is negative

I found that this could happen due to the `while (count--)` at line 687.