### PR TITLE
Make compilation work on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.log
 *.pdb
 *.tlog
+rnc32
+rnc64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+CFLAGS ?= -O3 -flto
+
 all: main.c
-	gcc -ggdb3 -O0 main.c -o rnc64
-	gcc -m32 -ggdb3 -O0 main.c -o rnc32
+	$(CC) $(CFLAGS) main.c -o rnc64
+	$(CC) $(CFLAGS) -m32 main.c -o rnc32
+.PHONY: all
+
 clean:
 	rm -f rnc64 rnc32
+.PHONY: clean

--- a/main.c
+++ b/main.c
@@ -1,11 +1,13 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifndef _WIN32
-#include <dir.h>
+#include <sys/stat.h>
 #else
 #include <direct.h>
+#define mkdir(name, mode) mkdir(name)
 #endif
 
 #ifndef _countof
@@ -1522,7 +1524,7 @@ int do_search(vars_t *v, size_t input_size, int save)
             if (save) {
                 FILE* out;
 
-                int dir_res = mkdir("extracted");
+                int dir_res = mkdir("extracted", S_IRWXU | S_IRWXG | S_IRWXO);
                 if (dir_res == -1 && errno != EEXIST) {
                     error_code = 12;
                     break;
@@ -1681,7 +1683,7 @@ int main(int argc, char *argv[])
     {
     case 'p': error_code = do_pack(v); break;
     case 'u': error_code = do_unpack(v); break;
-    case 's': 
+    case 's':
     case 'e': error_code = do_search(v, v->file_size, v->puse_mode == 'e'); break;
     }
 


### PR DESCRIPTION
- Use POSIX definition of `mkdir`, with a compatibility shim for Windows
- Use standard include for `errno`
- Allow overriding compilation flags
- Use optimized build by default
- Use system default C compiler, not necessarily GCC (and allow overriding)